### PR TITLE
Support generating completions using a `--completions` arg.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,10 +702,11 @@ dependencies = [
 
 [[package]]
 name = "sshping"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bytesize",
  "clap",
+ "clap_complete",
  "humantime",
  "indicatif",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ clap = { version = "4.5.7", features = [
   "color",
   "wrap_help",
 ] }
+clap_complete = "4.5.38"
 humantime = "2.1.0"
 indicatif = "0.17.8"
 log = "0.4.21"

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Currently, there are a few things that can be added but haven't been yet. If you
 - [x] Table style customization
 - [ ] Unit test
 - [ ] Man page generation
-- [ ] Shell autocompletion script generation
+- [x] Shell autocompletion script generation
 - [ ] Packaging for various platforms
 - [ ] More SSH tests
 - [ ] Better error handling

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,7 @@ use clap::{
     crate_authors, crate_description, crate_name, crate_version, ArgAction, Parser, ValueEnum,
     ValueHint,
 };
+use clap_complete::Shell;
 use shellexpand::tilde;
 use whoami::username;
 
@@ -21,7 +22,7 @@ use crate::style::TableStyle;
 #[command(styles = get_styles())]
 pub struct Options {
     /// [user@]host[:port]
-    #[arg(value_parser = parse_target, value_hint = ValueHint::Hostname)]
+    #[arg(value_parser = parse_target, value_hint = ValueHint::Hostname, group = "main_action", default_value = "")]
     pub target: Target,
 
     /// Read the ssh config file FILE for options
@@ -206,6 +207,15 @@ pub struct Options {
     /// -vvvv: Show trace messages
     #[arg(short, long, action = ArgAction::Count)]
     pub verbose: u8,
+
+    /// Print completions for the given shell (instead of doing anything else).
+    /// These can be loaded/stored permanently, but they can also be sourced directly.
+    /// For example:
+    ///
+    ///  source <(sshping --completions zsh) # zsh
+    ///  sshping --completions fish | source # fish
+    #[clap(long, verbatim_doc_comment, id = "SHELL", group = "main_action")]
+    pub completions: Option<Shell>,
 }
 
 #[derive(ValueEnum, Clone, PartialEq, Eq, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,14 @@ mod util;
 
 use std::{
     fs::File,
-    io::{BufReader, Read},
+    io::{stdout, BufReader, Read},
     net::TcpStream,
-    process::ExitCode,
+    process::{exit, ExitCode},
 };
 
 use auth::authenticate_all;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
+use clap_complete::generate;
 use cli::{Options, Test};
 use log::{debug, error, trace, LevelFilter};
 use simple_logger::SimpleLogger;
@@ -29,6 +30,10 @@ use util::Formatter;
 
 fn main() -> ExitCode {
     let mut opts = Options::parse();
+    if let Some(shell) = opts.completions {
+        generate(shell, &mut Options::command(), "sshping", &mut stdout());
+        exit(0);
+    }
 
     // Initialize logging
     SimpleLogger::new()


### PR DESCRIPTION
This arg is exclusive with the target, and one of the two must be specified.
